### PR TITLE
Adding 3000ms wait time before assertions in unit test

### DIFF
--- a/src/test/java/com/aws/iot/edgeconnectorforkvs/EdgeConnectorForKVSServiceTest.java
+++ b/src/test/java/com/aws/iot/edgeconnectorforkvs/EdgeConnectorForKVSServiceTest.java
@@ -285,6 +285,7 @@ public class EdgeConnectorForKVSServiceTest {
         edgeConnectorForKVSService.setUpCameraLevelEdgeConnectorForKVSService(edgeConnectorForKVSConfiguration);
 
         //verify
+        Thread.sleep(3000);
         assertEquals(0, edgeConnectorForKVSConfiguration.getRecordingRequestsCount());
         assertEquals(true, edgeConnectorForKVSConfiguration.getFatalStatus().get());
     }


### PR DESCRIPTION
*Issue #, if available: N/A

*Description of changes:*

Unit test failed because the assertion was executed before the mock setup is done, hence adding 3000ms wait time before assertions in unit test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
