### PR TITLE
Remove leading quote and trailing quote for windows platform

### DIFF
--- a/src/main/java/com/aws/iot/edgeconnectorforkvs/EdgeConnectorForKVSService.java
+++ b/src/main/java/com/aws/iot/edgeconnectorforkvs/EdgeConnectorForKVSService.java
@@ -860,6 +860,8 @@ public class EdgeConnectorForKVSService implements SchedulerCallback {
         List<String> restartNeededConfigurationList = new ArrayList<>();
         do {
             hubSiteWiseAssetId = args[Constants.ARG_INDEX_SITE_WISE_ASSET_ID_FOR_HUB];
+            // For windows, we need to remove leading quote and trailing quote
+            hubSiteWiseAssetId = hubSiteWiseAssetId.replaceAll("'", "");
             log.info("EdgeConnectorForKVS Hub Asset Id: " + hubSiteWiseAssetId);
             final EdgeConnectorForKVSService edgeConnectorForKVSService = new EdgeConnectorForKVSService();
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

On Windows platform, it added leading and trailing single quote to argument string, hence we have to remove them before calling SiteWise with the SiteWiseHubAssetId

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
